### PR TITLE
Add Playwright test for EPAM website navigation

### DIFF
--- a/tests/ClientWorkPage.ts
+++ b/tests/ClientWorkPage.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+
+export class ClientWorkPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async verifyClientWorkText() {
+    const clientWorkText = await this.page.getByText('Client Work');
+    await expect(clientWorkText).toBeVisible();
+  }
+}

--- a/tests/HomePage.ts
+++ b/tests/HomePage.ts
@@ -1,0 +1,17 @@
+import { Page } from '@playwright/test';
+
+export class HomePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigate() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServices() {
+    await this.page.getByRole('link', { name: 'Services', exact: true }).click();
+  }
+}

--- a/tests/ServicesPage.ts
+++ b/tests/ServicesPage.ts
@@ -1,0 +1,13 @@
+import { Page } from '@playwright/test';
+
+export class ServicesPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async clickExploreClientWork() {
+    await this.page.getByRole('link', { name: 'Explore Our Client Work' }).click();
+  }
+}

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test';
+import { HomePage } from './HomePage';
+import { ServicesPage } from './ServicesPage';
+import { ClientWorkPage } from './ClientWorkPage';
+
+test('Navigate to EPAM and verify Client Work', async ({ page }) => {
+  const homePage = new HomePage(page);
+  const servicesPage = new ServicesPage(page);
+  const clientWorkPage = new ClientWorkPage(page);
+
+  // Navigate to EPAM website
+  await homePage.navigate();
+
+  // Click on Services from the header menu
+  await homePage.clickServices();
+
+  // Click on Explore Our Client Work link
+  await servicesPage.clickExploreClientWork();
+
+  // Verify that the Client Work text is visible on the page
+  await clientWorkPage.verifyClientWorkText();
+});


### PR DESCRIPTION
This pull request adds a Playwright test scenario for navigating to the EPAM website, selecting "Services" from the header menu, clicking the "Explore Our Client Work" link, and verifying that the "Client Work" text is visible on the page.